### PR TITLE
opencv import 오류 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .ipynb_checkpoints
 data
 backup
+**/png/
+venv3/

--- a/run-jupyter.sh
+++ b/run-jupyter.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 source venv3/bin/activate
-jupyter notebook
+jupyter notebook $@
+
 

--- a/setup-jupyter-rpi.sh
+++ b/setup-jupyter-rpi.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+sudo apt-get install gfortran
+sudo apt-get install libatlas-base-dev
+sudo apt install libjasper-dev
+sudo apt install libqtgui4 python3-pyqt5 libqt4-test
+
+python3 -m venv venv3
+source venv3/bin/activate
+pip install --upgrade --force-reinstall --no-cache-dir jupyter;
+pip install numpy matplotlib scipy scikit-image
+# https://github.com/EdjeElectronics/TensorFlow-Object-Detection-on-the-Raspberry-Pi/issues/67#issuecomment-557679983
+pip install opencv-python==3.4.6.27
+pip install opencv-contrib-python
+

--- a/setup-jupyter.sh
+++ b/setup-jupyter.sh
@@ -2,6 +2,9 @@
 
 python3 -m venv venv3
 source venv3/bin/activate
-pip install --upgrade --force-reinstall --no-cache-dir jupyter;pip install numpy matplotlib scipy opencv-python scikit-image
-
+pip install --upgrade --force-reinstall --no-cache-dir jupyter;
+pip install numpy matplotlib scipy scikit-image
+# https://github.com/EdjeElectronics/TensorFlow-Object-Detection-on-the-Raspberry-Pi/issues/67#issuecomment-557679983
+pip install opencv-python==3.4.6.27
+pip install opencv-contrib-python
 


### PR DESCRIPTION
- cv2 import 오류 발생하는 경우 특정버전의 CV2 설치가 필요
  https://github.com/EdjeElectronics/TensorFlow-Object-Detection-on-the-Raspberry-Pi/issues/67#issuecomment-557679983

- rasberrypi 4(Raspbian GNU/Linux 10 (buster))에서 필요한 DEPENDENCIES들 설치
